### PR TITLE
Updating to use of native hashlib pbkdf2_hmac

### DIFF
--- a/fuzzy_extractor/__init__.py
+++ b/fuzzy_extractor/__init__.py
@@ -32,7 +32,7 @@ __description__ = 'A Python implementation of fuzzy extractor'
 from math import log
 from os import urandom
 from struct import pack, unpack
-from fastpbkdf2 import pbkdf2_hmac
+from hashlib import pbkdf2_hmac
 import numpy as np
 
 class FuzzyExtractor(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-fastpbkdf2>=0.2
 numpy>=1.12.1

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     download_url=extract_metaitem('download_url'),
     packages=find_packages(exclude=('tests', 'docs')),
     platforms=['Any'],
-    install_requires=['fastpbkdf2', 'numpy'],
+    install_requires=['numpy'],
     tests_require=['pytest'],
     keywords='fuzzy extractor security',
     classifiers=[
@@ -71,5 +71,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )


### PR DESCRIPTION
Removed use of fastpbkdf2 library who's lack of maintenance is causing setup and import issues in fuzzy_extractor. Using python native hashlib instead solves the issue as it is native and maintained. I also uses the same schema and naming convention so it works out of the box.